### PR TITLE
[CHR-2065] add debug in java, and experiment force usage of conf syst…

### DIFF
--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/SnowOwl.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/SnowOwl.java
@@ -147,16 +147,19 @@ public final class SnowOwl {
 		// check ENV variable
 		String confPath = System.getenv(SO_PATH_CONF_ENV);
 		if (!Strings.isNullOrEmpty(confPath)) {
+			log.info("conf path found via system env var: " + confPath);
 			return createPath(SO_PATH_CONF_ENV, confPath);
 		}
 		
 		// check System property
 		confPath = System.getProperty(SO_PATH_CONF);
 		if (!Strings.isNullOrEmpty(confPath)) {
+			log.info("conf path found via system property: " + confPath);
 			return createPath(SO_PATH_CONF, confPath);
 		}
 		
 		// as last resort, fall back to the default configuration folder SO_HOME/configuration
+		log.info("conf path not found, use default: " + DEFAULT_CONF_PATH);
 		return homePath.resolve(DEFAULT_CONF_PATH);
 	}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,10 @@ RUN mkdir -p /opt/snowowl/bbl/config
 #TODO restrict linux files permission
 RUN mv configuration/* $SO_PATH_CONF/
 
+#babylon hack since SO_PATH_CONF doesn't seem to be taken into account
+RUN rm -rf /usr/share/snowowl/configuration  && \
+ln -s $SO_PATH_CONF /usr/share/snowowl/configuration
+
 RUN ln -s $SO_PATH_CONF /etc/snowowl && \
     ln -s /usr/share/snowowl/resources /var/lib/snowowl && \
     ln -s /usr/share/snowowl/serviceability /var/log/snowowl

--- a/docker/bin/docker-entrypoint.sh
+++ b/docker/bin/docker-entrypoint.sh
@@ -11,4 +11,5 @@ if [[ "$1" != "sowrapper" ]]; then
 	exec "$@"
 fi
 
+echo "SO_PATH_CONF is $SO_PATH_CONF"
 exec /usr/share/snowowl/bin/snowowl.sh

--- a/releng/com.b2international.snowowl.server.update/assembly/common/bin/snowowl.sh
+++ b/releng/com.b2international.snowowl.server.update/assembly/common/bin/snowowl.sh
@@ -46,6 +46,7 @@ TMP_DIR=$KERNEL_HOME/work/tmp
 # Ensure that the tmp directory exists
 mkdir -p "$TMP_DIR"
 
+echo "SO_PATH_CONF env: $SO_PATH_CONF"
 SO_JAVA_OPTS="-Xms6g \
                 -Xmx6g \
                 -XX:+AlwaysPreTouch \
@@ -62,10 +63,17 @@ SO_JAVA_OPTS="-Xms6g \
                 -XX:+UseCMSInitiatingOccupancyOnly \
                 -XX:+HeapDumpOnOutOfMemoryError \
                 -Djdk.security.defaultKeySize=DSA:1024 \
+                -Dso.path.conf="$SO_PATH_CONF" \
                 $SO_JAVA_OPTS"
 
 pushd "$KERNEL_HOME"
 
+echo "JAVA_EXECUTABLE $JAVA_EXECUTABLE"
+echo "SO_JAVA_OPTS $SO_JAVA_OPTS"
+echo "TMP_DIR $TMP_DIR"
+echo "JAVA_EXECUTABLE $JAVA_EXECUTABLE"
+echo "KERNEL_HOME $KERNEL_HOME"
+echo "CONFIG_AREA $CONFIG_AREA"
 exec $JAVA_EXECUTABLE $SO_JAVA_OPTS \
   -Djava.io.tmpdir="$TMP_DIR" \
   -Dosgi.install.area="$KERNEL_HOME" \


### PR DESCRIPTION
…em prop java

- add log info in java to show which way is used to read conf folder path, sysenv , javaprop or default hardcoded
- add a symlink in docker, in case always using hardcoded
- print conf in shell startup script
- force use of `so.path.conf` (javaprop) way